### PR TITLE
Allow overriding the "process" method of the ExportHandler and ImportHandler

### DIFF
--- a/src/ExportHandler.php
+++ b/src/ExportHandler.php
@@ -145,7 +145,7 @@ class ExportHandler extends Handler
         }
 
         return response()->download(
-            self::process(
+            static::process(
                 $path,
                 $this->getResource(),
                 $query,

--- a/src/ImportHandler.php
+++ b/src/ImportHandler.php
@@ -129,7 +129,7 @@ class ImportHandler extends Handler
             return back();
         }
 
-        self::process(
+        static::process(
             $path,
             $this->getResource(),
             $this->deleteAfter,


### PR DESCRIPTION
Without this fix, it is impossible to extend the class and override only the process method, since self::process() always refers to the method of the original handler class.