### PR TITLE
Move import/export handlers to index pages for MoonShine 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,19 @@
 
 ## Requirements
 
-- MoonShine 4+
-- Laravel 10+
+- MoonShine 5.x
+- Laravel 11–13
 
 | Version | PHP       |
 |---------|-----------|
 | 2.0     | PHP 8.2+  |
 | 2.1     | PHP 8.3+  |
+| 3.0     | PHP 8.4+  |
 
 ## Installation
 
 ```shell
-composer require moonshine/import-export
+composer require moonshine/import-export:^3.0
 ```
 
 ## Usage
@@ -33,6 +34,20 @@ class CategoryResource extends ModelResource implements HasImportExportContract
     // ...
 }
 ```
+
+* In the resource's `IndexPage`, add `ImportExportHandlersConcern` to register the buttons and handlers.
+
+```php
+use MoonShine\ImportExport\Traits\ImportExportHandlersConcern;
+use MoonShine\Laravel\Pages\Crud\IndexPage;
+
+class CategoryIndexPage extends IndexPage
+{
+    use ImportExportHandlersConcern;
+}
+```
+
+Register `CategoryIndexPage::class` in the resource's `pages()` method alongside its form and detail pages.
 
 * Define the fields that will be involved in import and export.
 
@@ -74,7 +89,7 @@ public function afterImported(mixed $item): mixed
 }
 ```
 
-* Queue.
+* Queue (override these methods on the `IndexPage`).
 
 ```php
 protected function export(): ?Handler
@@ -92,3 +107,12 @@ protected function import(): ?Handler
     return ImportHandler::make(__('moonshine::ui.import'))->queue();
 }
 ```
+
+## Upgrading from 2.x
+
+Keep `ImportExportConcern`, `HasImportExportContract`, field definitions, and import events on the resource.
+Add `ImportExportHandlersConcern` to its index page. Move any `export()`, `import()`,
+`isExportToCsv()`, and `handlers()` overrides from the resource to that page.
+From a page override, use `$this->getResource()` to access the resource (for example,
+`->filename($this->getResource()->getUriKey())`). Handlers still receive the resource
+through the index page's `getHandlers()`, including for queued import and export.

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,10 @@
     }
   ],
   "require": {
-    "php": "^8.3",
+    "php": "^8.4",
     "ext-curl": "*",
     "ext-json": "*",
+    "moonshine/laravel": "^5.0",
     "rap2hpoutre/fast-excel": "^5.4"
   },
   "require-dev": {
@@ -35,8 +36,8 @@
     }
   },
   "conflict": {
-    "laravel/framework": "<10.48.0",
-    "moonshine/moonshine": "<4.0"
+    "laravel/framework": "<11.0",
+    "moonshine/moonshine": "<5.0"
   },
   "scripts": {
 

--- a/src/Traits/ImportExportConcern.php
+++ b/src/Traits/ImportExportConcern.php
@@ -6,43 +6,10 @@ namespace MoonShine\ImportExport\Traits;
 
 use MoonShine\Contracts\UI\FieldContract;
 use MoonShine\Laravel\Collections\Fields;
-use MoonShine\Crud\Handlers\Handler;
-use MoonShine\ImportExport\ExportHandler;
-use MoonShine\ImportExport\ImportHandler;
-use MoonShine\Support\ListOf;
 use Throwable;
 
 trait ImportExportConcern
 {
-    protected function isExportToCsv(): bool
-    {
-        return false;
-    }
-
-    protected function export(): ?Handler
-    {
-        return ExportHandler::make(__('moonshine::ui.export'))->when(
-            $this->isExportToCsv(),
-            static fn (ExportHandler $handler): ExportHandler => $handler->csv()
-        );
-    }
-
-    protected function import(): ?Handler
-    {
-        return ImportHandler::make(__('moonshine::ui.import'));
-    }
-
-    /**
-     * @return ListOf<Handler>
-     */
-    protected function handlers(): ListOf
-    {
-        return new ListOf(Handler::class, array_filter([
-            $this->export(),
-            $this->import(),
-        ]));
-    }
-
     /**
      * @return list<FieldContract>
      */

--- a/src/Traits/ImportExportHandlersConcern.php
+++ b/src/Traits/ImportExportHandlersConcern.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MoonShine\ImportExport\Traits;
+
+use MoonShine\Crud\Contracts\Page\IndexPageContract;
+use MoonShine\Crud\Handlers\Handler;
+use MoonShine\ImportExport\ExportHandler;
+use MoonShine\ImportExport\ImportHandler;
+use MoonShine\Support\ListOf;
+
+/**
+ * @mixin IndexPageContract
+ */
+trait ImportExportHandlersConcern
+{
+    protected function isExportToCsv(): bool
+    {
+        return false;
+    }
+
+    protected function export(): ?Handler
+    {
+        return ExportHandler::make(__('moonshine::ui.export'))->when(
+            $this->isExportToCsv(),
+            static fn (ExportHandler $handler): ExportHandler => $handler->csv()
+        );
+    }
+
+    protected function import(): ?Handler
+    {
+        return ImportHandler::make(__('moonshine::ui.import'));
+    }
+
+    /**
+     * @return ListOf<Handler>
+     */
+    protected function handlers(): ListOf
+    {
+        return new ListOf(Handler::class, array_filter([
+            $this->export(),
+            $this->import(),
+        ]));
+    }
+}


### PR DESCRIPTION
MoonShine 5 removes resource-level handler registration. Import/export buttons and handler routes must now use the resource’s index page.

This breaking change moves `export()`, `import()`, `isExportToCsv()`, and `handlers()` into `ImportExportHandlersConcern`, intended for `IndexPage`. `ImportExportConcern` stays on the resource with the existing field definitions and import events. Handler resource binding and queued processing continue through the existing page API.

Requires PHP 8.4 and MoonShine Laravel 5.x; the README explains migration from 2.x. Targets the new `3.x` branch; `2.x` is unchanged.

Validation with the local MoonShine 5 checkout after deprecated resource APIs were removed:
- PHP 8.4.21 / Laravel 13.30.1 / MySQL: 770 passed, 2188 assertions, 1 todo, 4 skipped, including import/export HTTP flows and default handler registration on IndexPage.
- MoonShine PHPStan: root and all nine packages passed at their existing levels.
- MoonShine Rector dry-run, changed-file formatting, Composer manifest validation, and Monorepo Builder validation passed.
- This package: Composer validation, PHP syntax checks, and diff whitespace checks passed.

Integration tests used a local copy of this branch. MoonShine’s development dependency has been updated locally to `^3.0`; merge and publish this package’s 3.x release before relying on a clean MoonShine dependency installation.
